### PR TITLE
Add feature for `-/+` instead of `</>`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,7 @@ rust:
   - 1.35.0
 script: |
   cargo build &&
+  cargo build --all-features &&
   cargo test &&
+  cargo test --all-features &&
   cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ categories = ["development-tools"]
 keywords = ["assert", "diff", "pretty", "color"]
 readme = "README.md"
 
+[features]
+default = []
+git-style-diff = []
+
 [badges]
 travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 

--- a/src/format_changeset.rs
+++ b/src/format_changeset.rs
@@ -9,8 +9,15 @@ macro_rules! paint {
     )
 }
 
+#[cfg(not(feature = "git-style-diff"))]
 const SIGN_RIGHT: char = '>'; // + > →
+#[cfg(not(feature = "git-style-diff"))]
 const SIGN_LEFT: char = '<'; // - < ←
+
+#[cfg(feature = "git-style-diff")]
+const SIGN_RIGHT: char = '+'; // + > →
+#[cfg(feature = "git-style-diff")]
+const SIGN_LEFT: char = '-'; // - < ←
 
 // Adapted from:
 // https://github.com/johannhof/difference.rs/blob/c5749ad7d82aa3d480c15cb61af9f6baa08f116f/examples/github-style.rs
@@ -169,8 +176,15 @@ fn test_format_replacement() {
         removed, added, buf
     );
 
+    #[cfg(not(feature = "git-style-diff"))]
     assert_eq!(
         buf,
         "\u{1b}[31m<\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0\u{1b}[0m\u{1b}[31m,\u{1b}[0m\n\u{1b}[31m<\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0,\u{1b}[0m\n\u{1b}[1;31m<\u{1b}[0m\u{1b}[1;48;5;52;31m    1\u{1b}[0m\u{1b}[31m2\u{1b}[0m\u{1b}[31m8,\u{1b}[0m\n\u{1b}[32m>\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[1;48;5;22;32m84\u{1b}[0m\u{1b}[32m,\u{1b}[0m\n\u{1b}[32m>\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[32m2\u{1b}[0m\u{1b}[1;48;5;22;32m4\u{1b}[0m\u{1b}[32m8,\u{1b}[0m\n"
+    );
+
+    #[cfg(feature = "git-style-diff")]
+    assert_eq!(
+        buf,
+        "\u{1b}[31m-\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0\u{1b}[0m\u{1b}[31m,\u{1b}[0m\n\u{1b}[31m-\u{1b}[0m\u{1b}[31m    \u{1b}[0m\u{1b}[1;48;5;52;31m0,\u{1b}[0m\n\u{1b}[1;31m-\u{1b}[0m\u{1b}[1;48;5;52;31m    1\u{1b}[0m\u{1b}[31m2\u{1b}[0m\u{1b}[31m8,\u{1b}[0m\n\u{1b}[32m+\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[1;48;5;22;32m84\u{1b}[0m\u{1b}[32m,\u{1b}[0m\n\u{1b}[32m+\u{1b}[0m\u{1b}[32m    \u{1b}[0m\u{1b}[32m2\u{1b}[0m\u{1b}[1;48;5;22;32m4\u{1b}[0m\u{1b}[32m8,\u{1b}[0m\n"
     );
 }

--- a/tests/assert_eq.rs
+++ b/tests/assert_eq.rs
@@ -19,6 +19,7 @@ extern crate difference;
  )
 
 "#)]
+#[cfg(not(feature = "git-style-diff"))]
 fn assert_eq() {
     #[derive(Debug, PartialEq)]
     struct Foo {
@@ -60,6 +61,7 @@ fn assert_eq() {
 
 "#
 )]
+#[cfg(not(feature = "git-style-diff"))]
 fn assert_eq_custom() {
     #[derive(Debug, PartialEq)]
     struct Foo {
@@ -108,6 +110,7 @@ fn assert_eq_with_comparable_types() {
  ]
 
 "#)]
+#[cfg(not(feature = "git-style-diff"))]
 fn issue12() {
     let left = vec![0, 0, 0, 128, 10, 191, 5, 64];
     let right = vec![84, 248, 45, 64];
@@ -131,6 +134,7 @@ fn issue12() {
  )
 
 "#)]
+#[cfg(not(feature = "git-style-diff"))]
 fn assert_eq_trailing_comma() {
     #[derive(Debug, PartialEq)]
     struct Foo {
@@ -172,6 +176,198 @@ fn assert_eq_trailing_comma() {
 
 "#
 )]
+#[cfg(not(feature = "git-style-diff"))]
+fn assert_eq_custom_trailing_comma() {
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok("hey".to_string()),
+    });
+    let y = Some(Foo {
+        lorem: "Hello Wrold!",
+        ipsum: 42,
+        dolor: Ok("hey ho!".to_string()),
+    });
+
+    assert_eq!(x, y, "custom panic message",);
+}
+
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+ Some(
+     Foo {
+[31m-[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
+[32m+[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m-[0m[31m            "hey[0m[31m",[0m
+[32m+[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+         ),
+     },
+ )
+
+"#)]
+#[cfg(feature = "git-style-diff")]
+fn assert_eq() {
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok("hey".to_string()),
+    });
+    let y = Some(Foo {
+        lorem: "Hello Wrold!",
+        ipsum: 42,
+        dolor: Ok("hey ho!".to_string()),
+    });
+
+    assert_eq!(x, y);
+}
+
+#[test]
+#[should_panic(
+    expected = r#"assertion failed: `(left == right)`: custom panic message
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+ Some(
+     Foo {
+[31m-[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
+[32m+[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m-[0m[31m            "hey[0m[31m",[0m
+[32m+[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+         ),
+     },
+ )
+
+"#
+)]
+#[cfg(feature = "git-style-diff")]
+fn assert_eq_custom() {
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok("hey".to_string()),
+    });
+    let y = Some(Foo {
+        lorem: "Hello Wrold!",
+        ipsum: 42,
+        dolor: Ok("hey ho!".to_string()),
+    });
+
+    assert_eq!(x, y, "custom panic message");
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+ [
+[31m-[0m[31m    [0m[1;48;5;52;31m0[0m[31m,[0m
+[31m-[0m[31m    [0m[1;48;5;52;31m0,[0m
+[1;31m-[0m[1;48;5;52;31m    0,[0m
+[1;31m-[0m[1;48;5;52;31m    1[0m[31m2[0m[31m8,[0m
+[31m-[0m[31m    [0m[1;48;5;52;31m10,[0m
+[1;31m-[0m[1;48;5;52;31m    191,[0m
+[1;31m-[0m[1;48;5;52;31m    [0m[31m5,[0m
+[32m+[0m[32m    [0m[1;48;5;22;32m84[0m[32m,[0m
+[32m+[0m[32m    [0m[32m2[0m[1;48;5;22;32m4[0m[32m8,[0m
+[32m+[0m[32m    [0m[1;48;5;22;32m4[0m[32m5,[0m
+     64,
+ ]
+
+"#)]
+#[cfg(feature = "git-style-diff")]
+fn issue12() {
+    let left = vec![0, 0, 0, 128, 10, 191, 5, 64];
+    let right = vec![84, 248, 45, 64];
+    assert_eq!(left, right);
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+ Some(
+     Foo {
+[31m-[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
+[32m+[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m-[0m[31m            "hey[0m[31m",[0m
+[32m+[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+         ),
+     },
+ )
+
+"#)]
+#[cfg(feature = "git-style-diff")]
+fn assert_eq_trailing_comma() {
+    #[derive(Debug, PartialEq)]
+    struct Foo {
+        lorem: &'static str,
+        ipsum: u32,
+        dolor: Result<String, String>,
+    }
+
+    let x = Some(Foo {
+        lorem: "Hello World!",
+        ipsum: 42,
+        dolor: Ok("hey".to_string()),
+    });
+    let y = Some(Foo {
+        lorem: "Hello Wrold!",
+        ipsum: 42,
+        dolor: Ok("hey ho!".to_string()),
+    });
+
+    assert_eq!(x, y,);
+}
+
+#[test]
+#[should_panic(
+    expected = r#"assertion failed: `(left == right)`: custom panic message
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+ Some(
+     Foo {
+[31m-[0m[31m        lorem: "Hello W[0m[31mo[0m[1;48;5;52;31mr[0m[31mld!",[0m
+[32m+[0m[32m        lorem: "Hello W[0m[1;48;5;22;32mr[0m[32mo[0m[32mld!",[0m
+         ipsum: 42,
+         dolor: Ok(
+[31m-[0m[31m            "hey[0m[31m",[0m
+[32m+[0m[32m            "hey[0m[1;48;5;22;32m ho![0m[32m",[0m
+         ),
+     },
+ )
+
+"#
+)]
+#[cfg(feature = "git-style-diff")]
 fn assert_eq_custom_trailing_comma() {
     #[derive(Debug, PartialEq)]
     struct Foo {

--- a/tests/assert_ne.rs
+++ b/tests/assert_ne.rs
@@ -86,6 +86,39 @@ fn assert_ne_non_empty_return() {
 [1;4mNote[0m: According to the `PartialEq` implementation, both of the values are partially equivalent, even if the `Debug` outputs differ.
 
 "#)]
+#[cfg(not(feature = "git-style-diff"))]
+fn assert_ne_partial() {
+    // Workaround for https://github.com/rust-lang/rust/issues/47619
+    // can be removed, when we require rust 1.25 or higher
+    struct Foo(f32);
+
+    use ::std::fmt;
+    impl fmt::Debug for Foo {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{:.1?}", self.0)
+        }
+    }
+
+    impl PartialEq for Foo {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    assert_ne!(Foo(-0.0), Foo(0.0));
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left != right)`
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+[31m-[0m[1;48;5;52;31m-[0m[31m0.0[0m
+[32m+[0m[32m0.0[0m
+
+[1;4mNote[0m: According to the `PartialEq` implementation, both of the values are partially equivalent, even if the `Debug` outputs differ.
+
+"#)]
+#[cfg(feature = "git-style-diff")]
 fn assert_ne_partial() {
     // Workaround for https://github.com/rust-lang/rust/issues/47619
     // can be removed, when we require rust 1.25 or higher

--- a/tests/pretty_string.rs
+++ b/tests/pretty_string.rs
@@ -22,6 +22,19 @@ impl<'a> fmt::Debug for PrettyString<'a> {
 [32m>foo
 [0m
 "#)]
+#[cfg(not(feature = "git-style-diff"))]
+fn assert_eq_empty_first() {
+    assert_eq!(PrettyString(""), PrettyString("foo"));
+}
+
+#[test]
+#[should_panic(expected = r#"assertion failed: `(left == right)`
+
+[1mDiff[0m [31m- left[0m / [32mright +[0m :
+[32m+foo
+[0m
+"#)]
+#[cfg(feature = "git-style-diff")]
 fn assert_eq_empty_first() {
     assert_eq!(PrettyString(""), PrettyString("foo"));
 }


### PR DESCRIPTION
Fixes #35 

If users prefer `-/+` to `</>`, they can add this to `Cargo.toml`:
```toml
[dev-dependencies]
pretty_assertions = { version = "*", features = ["git-style-diff"] }
```

This probably isn't the best name for the feature, so I'm open to suggestions :laughing: 