### PR TITLE
lib: add helpers for generating custom assert_{eq,ne} macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,6 @@
 members = [
     "pretty_assertions",
     "pretty_assertions_bench",
+    "pretty_assertions_derive",
+    "pretty_assertions_derive_tests",
 ]

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -23,6 +23,7 @@ travis-ci = { repository = "colin-kiegel/rust-pretty-assertions" }
 [dependencies]
 ansi_term = "0.12.1"
 diff = "0.1.12"
+pretty_assertions_derive = { version = "0.1.0", path = "../pretty_assertions_derive" }
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"

--- a/pretty_assertions/src/lib.rs
+++ b/pretty_assertions/src/lib.rs
@@ -126,115 +126,89 @@ where
     }
 }
 
-/// Asserts that two expressions are equal to each other (using [`PartialEq`]).
-///
-/// On panic, this macro will print a diff derived from [`Debug`] representation of
-/// each value.
-///
-/// This is a drop in replacement for [`std::assert_eq!`].
-/// You can provide a custom panic message if desired.
-///
-/// # Examples
-///
-/// ```
-/// use pretty_assertions::assert_eq;
-///
-/// let a = 3;
-/// let b = 1 + 2;
-/// assert_eq!(a, b);
-///
-/// assert_eq!(a, b, "we are testing addition with {} and {}", a, b);
-/// ```
-#[macro_export]
-macro_rules! assert_eq {
-    ($left:expr, $right:expr$(,)?) => ({
-        $crate::assert_eq!(@ $left, $right, "", "");
-    });
-    ($left:expr, $right:expr, $($arg:tt)*) => ({
-        $crate::assert_eq!(@ $left, $right, ": ", $($arg)+);
-    });
-    (@ $left:expr, $right:expr, $maybe_semicolon:expr, $($arg:tt)*) => ({
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if !(*left_val == *right_val) {
-                    ::std::panic!("assertion failed: `(left == right)`{}{}\
-                       \n\
-                       \n{}\
-                       \n",
-                       $maybe_semicolon,
-                       format_args!($($arg)*),
-                       $crate::Comparison::new(left_val, right_val)
-                    )
-                }
-            }
-        }
-    });
+pretty_assertions_derive::derive_assert_eq! {
+    /// Asserts that two expressions are equal to each other (using [`PartialEq`]).
+    ///
+    /// On panic, this macro will print a diff derived from [`Debug`] representation of
+    /// each value.
+    ///
+    /// This is a drop in replacement for [`std::assert_eq!`].
+    /// You can provide a custom panic message if desired.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pretty_assertions::assert_eq;
+    ///
+    /// let a = 3;
+    /// let b = 1 + 2;
+    /// assert_eq!(a, b);
+    ///
+    /// assert_eq!(a, b, "we are testing addition with {} and {}", a, b);
+    /// ```
+    (assert_eq, |left_val, right_val, has_message, message| {
+        ::std::panic!("assertion failed: `(left == right)`{}{}\
+           \n\
+           \n{}\
+           \n",
+           if has_message { ": " } else { "" },
+           message,
+           $crate::Comparison::new(left_val, right_val)
+        )
+    })
 }
 
-/// Asserts that two expressions are not equal to each other (using [`PartialEq`]).
-///
-/// On panic, this macro will print the values of the expressions with their
-/// [`Debug`] representations.
-///
-/// This is a drop in replacement for [`std::assert_ne!`].
-/// You can provide a custom panic message if desired.
-///
-/// # Examples
-///
-/// ```
-/// use pretty_assertions::assert_ne;
-///
-/// let a = 3;
-/// let b = 2;
-/// assert_ne!(a, b);
-///
-/// assert_ne!(a, b, "we are testing that the values are not equal");
-/// ```
-#[macro_export]
-macro_rules! assert_ne {
-    ($left:expr, $right:expr$(,)?) => ({
-        $crate::assert_ne!(@ $left, $right, "", "");
-    });
-    ($left:expr, $right:expr, $($arg:tt)+) => ({
-        $crate::assert_ne!(@ $left, $right, ": ", $($arg)+);
-    });
-    (@ $left:expr, $right:expr, $maybe_semicolon:expr, $($arg:tt)+) => ({
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if *left_val == *right_val {
-                    let left_dbg = ::std::format!("{:?}", &*left_val);
-                    let right_dbg = ::std::format!("{:?}", &*right_val);
-                    if left_dbg != right_dbg {
-                        ::std::panic!("assertion failed: `(left != right)`{}{}\
-                            \n\
-                            \n{}\
-                            \n{}: According to the `PartialEq` implementation, both of the values \
-                              are partially equivalent, even if the `Debug` outputs differ.\
-                            \n\
-                            \n",
-                            $maybe_semicolon,
-                            format_args!($($arg)+),
-                            $crate::Comparison::new(left_val, right_val),
-                            $crate::Style::new()
-                                .bold()
-                                .underline()
-                                .paint("Note")
-                        )
-                    }
-
-                    ::std::panic!("assertion failed: `(left != right)`{}{}\
-                        \n\
-                        \n{}:\
-                        \n{:#?}\
-                        \n\
-                        \n",
-                        $maybe_semicolon,
-                        format_args!($($arg)+),
-                        $crate::Style::new().bold().paint("Both sides"),
-                        left_val
-                    )
-                }
-            }
+pretty_assertions_derive::derive_assert_ne! {
+    /// Asserts that two expressions are not equal to each other (using [`PartialEq`]).
+    ///
+    /// On panic, this macro will print the values of the expressions with their
+    /// [`Debug`] representations.
+    ///
+    /// This is a drop in replacement for [`std::assert_ne!`].
+    /// You can provide a custom panic message if desired.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pretty_assertions::assert_ne;
+    ///
+    /// let a = 3;
+    /// let b = 2;
+    /// assert_ne!(a, b);
+    ///
+    /// assert_ne!(a, b, "we are testing that the values are not equal");
+    /// ```
+    (assert_ne, |left_val, right_val, has_message, message| {
+        let left_dbg = ::std::format!("{:?}", &*left_val);
+        let right_dbg = ::std::format!("{:?}", &*right_val);
+        if left_dbg != right_dbg {
+            ::std::panic!("assertion failed: `(left != right)`{}{}\
+                \n\
+                \n{}\
+                \n{}: According to the `PartialEq` implementation, both of the values \
+                  are partially equivalent, even if the `Debug` outputs differ.\
+                \n\
+                \n",
+                if has_message { ": " } else { "" },
+                message,
+                $crate::Comparison::new(left_val, right_val),
+                $crate::Style::new()
+                    .bold()
+                    .underline()
+                    .paint("Note")
+            )
         }
-    });
+
+        ::std::panic!("assertion failed: `(left != right)`{}{}\
+            \n\
+            \n{}:\
+            \n{:#?}\
+            \n\
+            \n",
+            if has_message { ": " } else { "" },
+            message,
+            $crate::Style::new().bold().paint("Both sides"),
+            left_val
+        )
+    })
 }

--- a/pretty_assertions_bench/Cargo.toml
+++ b/pretty_assertions_bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "pretty_assertions_bench"
 version = "0.1.0"
 authors = ["Tom Milligan <code@tommilligan.net>"]
 edition = "2018"
+publish = false
 
 [dependencies]
 criterion = { version = "0.3.4", features = ["html_reports"] }

--- a/pretty_assertions_derive/Cargo.toml
+++ b/pretty_assertions_derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pretty_assertions_derive"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.26"
+quote = "1.0.9"
+syn = { version = "1.0.71", features = ["full"] }

--- a/pretty_assertions_derive/src/lib.rs
+++ b/pretty_assertions_derive/src/lib.rs
@@ -1,0 +1,284 @@
+//! # pretty_assertions_derive
+//!
+//! Used to produce custom `assert_eq` and `assert_ne` drop-in implementations, without
+//! the boilerplate.
+//!
+//! For further documentation, see [`derive_assert_eq!`] and [`derive_assert_ne!`].
+
+#![deny(clippy::all, unsafe_code)]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+
+struct ParsedItem {
+    attrs: Vec<syn::Attribute>,
+    body: Box<syn::Expr>,
+    name: syn::PathSegment,
+    ident_left: syn::Ident,
+    ident_right: syn::Ident,
+    ident_has_message: syn::Ident,
+    ident_message: syn::Ident,
+}
+
+impl From<syn::ExprTuple> for ParsedItem {
+    fn from(item: syn::ExprTuple) -> Self {
+        let syn::ExprTuple { attrs, elems, .. } = item;
+        let mut arguments = elems.into_iter();
+        let mut name_segments = match arguments
+            .next()
+            .expect("input must be a tuple of two elements")
+        {
+            syn::Expr::Path(expr_path) => expr_path.path.segments.into_iter(),
+            _ => panic!("first element must be an ident"),
+        };
+        let name = name_segments
+            .next()
+            .expect("first element must be an ident");
+        if name_segments.next().is_some() {
+            panic!("first element must be an ident");
+        }
+        let closure = match arguments
+            .next()
+            .expect("input must be a tuple of two elements")
+        {
+            syn::Expr::Closure(closure) => closure,
+            _ => panic!("second element must be a closure"),
+        };
+
+        let syn::ExprClosure { body, inputs, .. } = closure;
+        let mut closure_idents = inputs
+            .into_iter()
+            .enumerate()
+            .map(|(index, input)| match input {
+                syn::Pat::Ident(pat_ident) => pat_ident.ident,
+                _ => panic!("closure input at position '{}' was not an ident", index),
+            });
+        let ident_left = closure_idents
+            .next()
+            .expect("source closure must have four arguments");
+        let ident_right = closure_idents
+            .next()
+            .expect("source closure must have four arguments");
+        let ident_has_message = closure_idents
+            .next()
+            .expect("source closure must have four arguments");
+        let ident_message = closure_idents
+            .next()
+            .expect("source closure must have four arguments");
+
+        Self {
+            attrs,
+            body,
+            name,
+            ident_left,
+            ident_right,
+            ident_has_message,
+            ident_message,
+        }
+    }
+}
+
+/// Derive a drop in replacement for `assert_eq`. When the equality check fails,
+/// the given closure will be called.
+///
+/// ## Limitations
+///
+/// Derived macro definitions cannot be called within the same crate. You muct define your custom
+/// macros in an external crate, and then import them before use in your tests.
+///
+/// If you call a derived macro within the same crate, you will see a compiler error such as:
+///
+/// ```log
+///  error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
+///   --> src/lib.rs:107:1
+///    |
+/// 4  | / pretty_assertions_derive::derive_assert_eq! {
+/// 5  | |     (assert_eq_custom, |left, right, has_message, message| {
+/// ...  |         // your custom macro definition here
+/// 20 | |     }
+/// 19 | | }
+///    | |_^
+/// 20 |
+/// 21 |   assert_eq_custom!(3, 2);
+///    |   ------------------------------ in this macro invocation
+///    |
+///    = note: `#[deny(macro_expanded_macro_exports_accessed_by_absolute_paths)]` on by default
+///    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+///    = note: for more information, see issue #52234 <https://github.com/rust-lang/rust/issues/52234>
+/// ```
+///
+/// ## Arguments
+///
+/// [`derive_assert_eq!`] accepts a single tuple with two items. Any annotations present on the tuple
+/// (such as docstrings) will be transferred to the generated macro definiton.
+///
+/// ### Name
+///
+/// The first argument must be the name of the macro to produce.
+///
+/// ### Closure
+///
+/// The closure will be called when the equality check of the two values fails, and must accept
+/// exactly four arguments itself. These are:
+///
+/// - `left: &T`, a reference to the left value
+/// - `right: &U`, a reference to the right value
+/// - `has_message: bool`, `true` if a custom panic message was given in the invocation
+/// - `message: String`, the value of the custom message, or an empty `String`
+///
+/// ## Examples
+///
+/// Derive a macro named `assert_eq_emoji`, which adds emoji flair around each value.
+///
+/// ```rust
+/// pretty_assertions_derive::derive_assert_eq! {
+///     /// Emojified `assert_eq`.
+///     (assert_eq_emoji, |left, right, has_message, message| {
+///         ::std::panic!("😱 Values should be equal! 😱{}{}\
+///            \n\
+///            \n🎯 {} 🎯\
+///            \n\
+///            \n💥 {} 💥\
+///            \n",
+///            if has_message { "\n-> with custom message: " } else { "" },
+///            message,
+///            left,
+///            right,
+///         )
+///     })
+/// }
+/// ```
+///
+/// A sample failure:
+///
+/// ```log
+/// thread 'main' panicked at '😱 Values should be equal! 😱
+///
+/// 🎯 3 🎯
+///
+/// 💥 2 💥
+/// ', pretty_assertions_derive_tests/examples/assert_emoji.rs:6:46
+/// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+/// ```
+#[proc_macro]
+pub fn derive_assert_eq(item: TokenStream) -> TokenStream {
+    let item_tuple = syn::parse_macro_input!(item as syn::ExprTuple);
+    let ParsedItem {
+        attrs,
+        body,
+        name,
+        ident_left,
+        ident_right,
+        ident_has_message,
+        ident_message,
+    } = ParsedItem::from(item_tuple);
+
+    let result = quote! {
+        #(#attrs)*
+        #[macro_export]
+        macro_rules! #name {
+            ($left:expr, $right:expr $(,)?) => ({
+                $crate::#name!(@ $left, $right, false, "");
+            });
+            ($left:expr, $right:expr, $($arg:tt)*) => ({
+                $crate::#name!(@ $left, $right, true, $($arg)+);
+            });
+            (@ $left:expr, $right:expr, $has_additional_args:expr, $($arg:tt)*) => ({
+                match (&($left), &($right)) {
+                    (__pretty_assertions_derive_left_val, __pretty_assertions_derive_right_val) => {
+                        if !(*__pretty_assertions_derive_left_val == *__pretty_assertions_derive_right_val) {
+                            let #ident_left = __pretty_assertions_derive_left_val;
+                            let #ident_right = __pretty_assertions_derive_right_val;
+                            let #ident_has_message = $has_additional_args;
+                            let #ident_message = ::std::format!($($arg)*);
+                            #body
+                        }
+                    }
+                }
+            });
+        }
+    };
+    result.into()
+}
+
+/// Derive a drop in replacement for `assert_ne`. When the equality check passes,
+/// the given closure will be called.
+///
+/// See [`derive_assert_eq!`] for further details, usage is identical.
+///
+/// ## Examples
+///
+/// Derive a macro named `assert_ne_emoji`, which adds emoji flair around each value.
+///
+/// ```rust
+/// pretty_assertions_derive::derive_assert_ne! {
+///     /// Emojified `assert_ne`.
+///     (assert_ne_emoji, |left, right, has_message, message| {
+///         ::std::panic!("😱 Values should not be equal! 😱{}{}\
+///            \n\
+///            \n🔥 {} 🔥\
+///            \n\
+///            \n🔥 {} 🔥\
+///            \n",
+///            if has_message { "\n-> with custom message: " } else { "" },
+///            message,
+///            left,
+///            right,
+///         )
+///     })
+/// }
+/// ```
+///
+/// A sample failure:
+///
+/// ```log
+/// thread 'main' panicked at '😱 Values should not be equal! 😱
+/// -> with custom message: additional details
+///
+/// 🔥 3 🔥
+///
+/// 🔥 3 🔥
+/// ', pretty_assertions_derive_tests/examples/assert_emoji.rs:12:46
+/// ```
+#[proc_macro]
+pub fn derive_assert_ne(item: TokenStream) -> TokenStream {
+    let item_tuple = syn::parse_macro_input!(item as syn::ExprTuple);
+    let ParsedItem {
+        attrs,
+        body,
+        name,
+        ident_left,
+        ident_right,
+        ident_has_message,
+        ident_message,
+    } = ParsedItem::from(item_tuple);
+
+    let result = quote! {
+        #(#attrs)*
+        #[macro_export]
+        macro_rules! #name {
+            ($left:expr, $right:expr $(,)?) => ({
+                $crate::#name!(@ $left, $right, false, "");
+            });
+            ($left:expr, $right:expr, $($arg:tt)*) => ({
+                $crate::#name!(@ $left, $right, true, $($arg)+);
+            });
+            (@ $left:expr, $right:expr, $has_additional_args:expr, $($arg:tt)*) => ({
+                match (&($left), &($right)) {
+                    (__pretty_assertions_derive_left_val, __pretty_assertions_derive_right_val) => {
+                        if *__pretty_assertions_derive_left_val == *__pretty_assertions_derive_right_val {
+                            let #ident_left = __pretty_assertions_derive_left_val;
+                            let #ident_right = __pretty_assertions_derive_right_val;
+                            let #ident_has_message = $has_additional_args;
+                            let #ident_message = ::std::format!($($arg)*);
+                            #body
+                        }
+                    }
+                }
+            });
+        }
+    };
+    result.into()
+}

--- a/pretty_assertions_derive_tests/Cargo.toml
+++ b/pretty_assertions_derive_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pretty_assertions_derive_tests"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+pretty_assertions_derive = { path = "../pretty_assertions_derive" }

--- a/pretty_assertions_derive_tests/examples/assert_emoji.rs
+++ b/pretty_assertions_derive_tests/examples/assert_emoji.rs
@@ -1,0 +1,17 @@
+#![allow(clippy::eq_op)]
+
+use pretty_assertions_derive_tests::{assert_eq_emoji, assert_ne_emoji};
+
+fn main() {
+    println!("Deliberate `assert_eq` panic:");
+    println!("---");
+    let result = std::panic::catch_unwind(|| assert_eq_emoji!(3, 2));
+    assert!(result.is_err(), "example did not panic");
+    println!();
+
+    println!("Deliberate `assert_ne` panic:");
+    println!("---");
+    let result = std::panic::catch_unwind(|| assert_ne_emoji!(3, 3, "additional {}", "details"));
+    assert!(result.is_err(), "example did not panic");
+    println!();
+}

--- a/pretty_assertions_derive_tests/src/lib.rs
+++ b/pretty_assertions_derive_tests/src/lib.rs
@@ -1,0 +1,49 @@
+//! Derives some custom macros for use in tests examples. Due to macro hoising/import limitations,
+//! this must be done in a separate crate.
+
+#![deny(clippy::all, missing_docs, unsafe_code)]
+
+pretty_assertions_derive::derive_assert_eq!(
+    /// A simple plain text assertion format for easy reading tests.
+    (assert_eq_custom, |l, r, h, m| {
+        if h {
+            ::std::panic!("{:?} != {:?}: {}", l, r, m)
+        } else {
+            ::std::panic!("{:?} != {:?}: <no additional message>", l, r)
+        }
+    })
+);
+
+pretty_assertions_derive::derive_assert_eq! {
+    /// Emojified `assert_eq`.
+    (assert_eq_emoji, |left, right, has_message, message| {
+        ::std::panic!("😱 Values should be equal! 😱{}{}\
+           \n\
+           \n🎯 {} 🎯\
+           \n\
+           \n💥 {} 💥\
+           \n",
+           if has_message { "\n-> with custom message: " } else { "" },
+           message,
+           left,
+           right,
+        )
+    })
+}
+
+pretty_assertions_derive::derive_assert_ne! {
+    /// Emojified `assert_ne`.
+    (assert_ne_emoji, |left, right, has_message, message| {
+        ::std::panic!("😱 Values should not be equal! 😱{}{}\
+           \n\
+           \n🔥 {} 🔥\
+           \n\
+           \n🔥 {} 🔥\
+           \n",
+           if has_message { "\n-> with custom message: " } else { "" },
+           message,
+           left,
+           right,
+        )
+    })
+}

--- a/pretty_assertions_derive_tests/tests/assert_eq.rs
+++ b/pretty_assertions_derive_tests/tests/assert_eq.rs
@@ -1,0 +1,18 @@
+use pretty_assertions_derive_tests::assert_eq_custom;
+
+#[test]
+fn assert_eq_custom_pass() {
+    assert_eq_custom!(3, 1 + 2);
+}
+
+#[test]
+#[should_panic(expected = r#"3 != 2: <no additional message>"#)]
+fn assert_eq_custom_fail() {
+    assert_eq_custom!(3, 2);
+}
+
+#[test]
+#[should_panic(expected = r#"3 != 2: message with var: 71"#)]
+fn assert_eq_custom_fail_message() {
+    assert_eq_custom!(3, 2, "message with var: {}", 71);
+}

--- a/scripts/check
+++ b/scripts/check
@@ -24,3 +24,4 @@ cargo doc --no-deps
 eprintln "Running examples"
 cargo run --example standard_assertion
 cargo run --example pretty_assertion
+cargo run --example assert_emoji


### PR DESCRIPTION
This PR uses proc macro magic to cut down the boilerplate needed to define macros that fit the `assert_eq` and `assert_ne` api. Our own `assert_eq` is now simply defined as:

```rust
pretty_assertions_derive::derive_assert_eq! {
    (assert_eq, |left_val, right_val, has_message, message| {
        ::std::panic!("assertion failed: `(left == right)`{}{}\
           \n\
           \n{}\
           \n",
           if has_message { ": " } else { "" },
           message,
           $crate::Comparison::new(left_val, right_val)
        )
    })
```

I'm going to leave this here for comment, as I'm not certain I want to merge this into `pretty_assertions`. I think it could feasibly be it's own crate and used in combination with `pretty_assertions`, for users who don't care abbout the additional dependency weight.

### Pros

- Nice and readable
- Extensible to other `assert_eq` definitions (see https://github.com/colin-kiegel/rust-pretty-assertions/issues/24#issuecomment-821482452)

### Cons

- Increases dependency tree
  - proc-macro2
    - unicode-xid
  - quote
  - syn
- Additional layer of complexity
  - Adds proc macros to the stack
  - Nested macro definitions!
- Macros produced using this definition cannot be called within in the same crate.

#### Potential workarounds (dismissed)

- Don't implement `pretty_assertion`'s core implementations using these procedural macros.
  - This would cut dependencies, but lead to duplicate code (which would be a pain to maintain).
- Try to implement matching functionality in plain macros.
  - I think this is theoretically possible but not fun.
