### PR TITLE
replace ansi_term with yansi

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.35.0
+          - 1.54.0
         experimental:
           - false
         # Run a canary test on nightly that's allowed to fail

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -30,7 +30,7 @@ alloc = []
 unstable = []
 
 [dependencies]
-ansi_term = "0.12.1"
+yansi = "0.5"
 diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]

--- a/pretty_assertions/src/lib.rs
+++ b/pretty_assertions/src/lib.rs
@@ -80,7 +80,6 @@
 #[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-pub use ansi_term::Style;
 use core::fmt::{self, Debug, Display};
 
 mod printer;
@@ -335,13 +334,12 @@ macro_rules! assert_ne {
                 if *left_val == *right_val {
                     ::core::panic!("assertion failed: `(left != right)`{}{}\
                         \n\
-                        \n{}:\
+                        \nBoth sides:\
                         \n{:#?}\
                         \n\
                         \n",
                         $maybe_colon,
                         format_args!($($arg)+),
-                        $crate::Style::new().bold().paint("Both sides"),
                         left_val
                     )
                 }

--- a/pretty_assertions/tests/macros.rs
+++ b/pretty_assertions/tests/macros.rs
@@ -234,7 +234,7 @@ mod assert_ne {
     #[test]
     #[should_panic(expected = r#"assertion failed: `(left != right)`
 
-[1mBoth sides[0m:
+Both sides:
 666
 "#)]
     fn fails() {
@@ -244,7 +244,7 @@ mod assert_ne {
     #[test]
     #[should_panic(expected = r#"assertion failed: `(left != right)`
 
-[1mBoth sides[0m:
+Both sides:
 666
 "#)]
     fn fails_trailing_comma() {
@@ -254,7 +254,7 @@ mod assert_ne {
     #[test]
     #[should_panic(expected = r#"assertion failed: `(left != right)`
 
-[1mBoth sides[0m:
+Both sides:
 [
     101,
 ]
@@ -269,7 +269,7 @@ mod assert_ne {
     #[should_panic(
         expected = r#"assertion failed: `(left != right)`: custom panic message
 
-[1mBoth sides[0m:
+Both sides:
 666
 "#
     )]
@@ -281,7 +281,7 @@ mod assert_ne {
     #[should_panic(
         expected = r#"assertion failed: `(left != right)`: custom panic message
 
-[1mBoth sides[0m:
+Both sides:
 666
 "#
     )]


### PR DESCRIPTION
Fixes #101 

Technically a breaking change because `ansi_term::Style` is publicly-exported (due to the way the macros are constructed), but I would be very surprised if anyone was relying on it.