### PR TITLE
chore: prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,34 +4,34 @@
 
 ## Changed
 
-- MSRV bumped to 1.54.0 (see [#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102))
-- Removed the publically re-exported `ansi_term::Style`. This was never intended for public use. (see [#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102))
+- MSRV bumped to 1.54.0 (see [#102](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/102))
+- Removed the publically re-exported `ansi_term::Style`. This was never intended for public use. (see [#102](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/102))
 
 ## Fixed
 
-- Moved from the unmaintained `ansi_term` crate to `yansi` for ANSI terminal escape code support. Thanks to [@Roguelazer](https://github.com/Roguelazer) for reporting and fixing this! ([#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102), [@Roguelazer](https://github.com/Roguelazer))
+- Moved from the unmaintained `ansi_term` crate to `yansi` for ANSI terminal escape code support. Thanks to [@Roguelazer](https://github.com/Roguelazer) for reporting and fixing this! ([#102](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/102), [@Roguelazer](https://github.com/Roguelazer))
 
 # v1.2.1
 
 ## Fixed
 
-- Fixed a panic caused by diffing two `str`-like values where only the left has a trailing newline - thanks [@Michael-F-Bryan](https://github.com/Michael-F-Bryan) for reporting this ([#97](https://github.com/colin-kiegel/rust-pretty-assertions/pull/97), [@tommilligan](https://github.com/tommilligan))
+- Fixed a panic caused by diffing two `str`-like values where only the left has a trailing newline - thanks [@Michael-F-Bryan](https://github.com/Michael-F-Bryan) for reporting this ([#97](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/97), [@tommilligan](https://github.com/tommilligan))
 
 # v1.2.0
 
 ## Changed
 
-- `assert_eq` compares `str`-like values without `Debug` formatting. ([#92](https://github.com/colin-kiegel/rust-pretty-assertions/pull/92), [@dtolnay](https://github.com/dtolnay))
+- `assert_eq` compares `str`-like values without `Debug` formatting. ([#92](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/92), [@dtolnay](https://github.com/dtolnay))
 
 # v1.1.0
 
 ## Added
 
-- Add `assert_str_eq` for comparing two `str`-like values without `Debug` formatting. Thanks to [@x3ro](https://github.com/x3ro) for implementing this! ([#88](https://github.com/colin-kiegel/rust-pretty-assertions/pull/88), [@x3ro](https://github.com/x3ro))
+- Add `assert_str_eq` for comparing two `str`-like values without `Debug` formatting. Thanks to [@x3ro](https://github.com/x3ro) for implementing this! ([#88](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/88), [@x3ro](https://github.com/x3ro))
 
 ## Fixed
 
-- Ensure license text is included in crate archive - thanks [@decathorpe](https://github.com/decathorpe) for reporting this ([#87](https://github.com/colin-kiegel/rust-pretty-assertions/pull/87), [@tommilligan](https://github.com/tommilligan))
+- Ensure license text is included in crate archive - thanks [@decathorpe](https://github.com/decathorpe) for reporting this ([#87](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/87), [@tommilligan](https://github.com/tommilligan))
 
 # v1.0.0
 
@@ -41,43 +41,43 @@
 
 ## Added
 
-- Officially support `no_std` (thanks to [@Luro02](https://github.com/Luro02) for the report and reviews!). Adds the `std` and `alloc` features to the `pretty_assertions` crate, with `std` enabled by default ([#83](https://github.com/colin-kiegel/rust-pretty-assertions/pull/83), [@tommilligan](https://github.com/tommilligan))
-- Adds the `unstable` feature to the `pretty_assertions` crate, for use with nightly rustc ([#81](https://github.com/colin-kiegel/rust-pretty-assertions/pull/81), [@tommilligan](https://github.com/tommilligan))
-- Add a drop in replacement for the unstable stdlib `assert_matches` macro, behind the `unstable` flag - thanks [@gilescope](https://github.com/gilescope) for the suggestion! ([#81](https://github.com/colin-kiegel/rust-pretty-assertions/issues/81), [@tommilligan](https://github.com/tommilligan))
+- Officially support `no_std` (thanks to [@Luro02](https://github.com/Luro02) for the report and reviews!). Adds the `std` and `alloc` features to the `pretty_assertions` crate, with `std` enabled by default ([#83](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/83), [@tommilligan](https://github.com/tommilligan))
+- Adds the `unstable` feature to the `pretty_assertions` crate, for use with nightly rustc ([#81](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/81), [@tommilligan](https://github.com/tommilligan))
+- Add a drop in replacement for the unstable stdlib `assert_matches` macro, behind the `unstable` flag - thanks [@gilescope](https://github.com/gilescope) for the suggestion! ([#81](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/81), [@tommilligan](https://github.com/tommilligan))
 
 # v0.7.2
 
-- Fix macro hygiene for expansion in a `no_implicit_prelude` context ([#70](https://github.com/colin-kiegel/rust-pretty-assertions/issues/70), [@tommilligan](https://github.com/tommilligan))
+- Fix macro hygiene for expansion in a `no_implicit_prelude` context ([#70](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/70), [@tommilligan](https://github.com/tommilligan))
 
 # v0.7.1
 
-- Fix a bug where multiline changes showed an unhelpful inline diff ([#66](https://github.com/colin-kiegel/rust-pretty-assertions/issues/66), [@tommilligan](https://github.com/tommilligan))
+- Fix a bug where multiline changes showed an unhelpful inline diff ([#66](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/66), [@tommilligan](https://github.com/tommilligan))
 
 # v0.7.0
 
 ## Changed
 
-- Move from `difference` to `diff` for calculating diffs. The exact assertion messages generated may differ from previous versions. ([#52](https://github.com/colin-kiegel/rust-pretty-assertions/issues/52), [@tommilligan](https://github.com/tommilligan))
+- Move from `difference` to `diff` for calculating diffs. The exact assertion messages generated may differ from previous versions. ([#52](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/52), [@tommilligan](https://github.com/tommilligan))
 
 For example, the following assertion message from `v0.7.0`:
 
-![pretty assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
+![pretty assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
 
 Was previously rendered like this in `v0.6.1`:
 
-![pretty assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion_v0_6_1.png)
+![pretty assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion_v0_6_1.png)
 
 ## Added
 
-- Support for unsized values ([#42](https://github.com/colin-kiegel/rust-pretty-assertions/issues/42), [@stanislav-tkach](https://github.com/stanislav-tkach))
-- Document the `Comparison` struct, which was previously hidden. This can be used to generate a pretty diff of two values without panicking. ([#52](https://github.com/colin-kiegel/rust-pretty-assertions/issues/52), [@tommilligan](https://github.com/tommilligan))
+- Support for unsized values ([#42](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/42), [@stanislav-tkach](https://github.com/stanislav-tkach))
+- Document the `Comparison` struct, which was previously hidden. This can be used to generate a pretty diff of two values without panicking. ([#52](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/52), [@tommilligan](https://github.com/tommilligan))
 
 ## Fixed
 
-- Fix some unhygenic macro expansions ([#41](https://github.com/colin-kiegel/rust-pretty-assertions/issues/41), [@tommilligan](https://github.com/tommilligan))
+- Fix some unhygenic macro expansions ([#41](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/41), [@tommilligan](https://github.com/tommilligan))
 
 ## Internal
 
-- Test Windows targets in CI ([#46](https://github.com/colin-kiegel/rust-pretty-assertions/issues/46), [@tommilligan](https://github.com/tommilligan))
-- Bump `ansi_term` version to 0.12 ([#34](https://github.com/colin-kiegel/rust-pretty-assertions/issues/34), [@waywardmonkeys](https://github.com/waywardmonkeys))
-- Code health improvements ([#34](https://github.com/colin-kiegel/rust-pretty-assertions/issues/34), [@waywardmonkeys](https://github.com/waywardmonkeys))
+- Test Windows targets in CI ([#46](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/46), [@tommilligan](https://github.com/tommilligan))
+- Bump `ansi_term` version to 0.12 ([#34](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/34), [@waywardmonkeys](https://github.com/waywardmonkeys))
+- Code health improvements ([#34](https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/34), [@waywardmonkeys](https://github.com/waywardmonkeys))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Unreleased
 
+# v1.3.0
+
+## Changed
+
+- MSRV bumped to 1.54.0 (see [#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102))
+- Removed the publically re-exported `ansi_term::Style`. This was never intended for public use. (see [#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102))
+
+## Fixed
+
+- Moved from the unmaintained `ansi_term` crate to `yansi` for ANSI terminal escape code support. Thanks to [@Roguelazer](https://github.com/Roguelazer) for reporting and fixing this! ([#102](https://github.com/colin-kiegel/rust-pretty-assertions/pull/102), [@Roguelazer](https://github.com/Roguelazer))
+
 # v1.2.1
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ If such a test fails, it will present all the details of `a` and `b`.
 But you have to spot the differences yourself, which is not always straightforward,
 like here:
 
-![standard assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/standard_assertion.png)
+![standard assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/standard_assertion.png)
 
 Wouldn't that task be _much_ easier with a colorful diff?
 
-![pretty assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
+![pretty assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
 
 Yep — and you only need **one line of code** to make it happen:
 

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 edition = "2018"
 
 description = "Overwrite `assert_eq!` and `assert_ne!` with drop-in replacements, adding colorful diffs."
-repository = "https://github.com/colin-kiegel/rust-pretty-assertions"
+repository = "https://github.com/rust-pretty-assertions/rust-pretty-assertions"
 documentation = "https://docs.rs/pretty_assertions"
 
 license = "MIT OR Apache-2.0"

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pretty_assertions"
-version = "1.2.1"
+version = "1.3.0"
 authors = [
     "Colin Kiegel <kiegel@gmx.de>",
     "Florent Fayolle <florent.fayolle69@gmail.com>",

--- a/pretty_assertions/src/lib.rs
+++ b/pretty_assertions/src/lib.rs
@@ -6,11 +6,11 @@
 //! But you have to spot the differences yourself, which is not always straightforward,
 //! like here:
 //!
-//! ![standard assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/standard_assertion.png)
+//! ![standard assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/standard_assertion.png)
 //!
 //! Wouldn't that task be _much_ easier with a colorful diff?
 //!
-//! ![pretty assertion](https://raw.githubusercontent.com/colin-kiegel/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
+//! ![pretty assertion](https://raw.githubusercontent.com/rust-pretty-assertions/rust-pretty-assertions/2d2357ff56d22c51a86b2f1cfe6efcee9f5a8081/examples/pretty_assertion.png)
 //!
 //! Yep — and you only need **one line of code** to make it happen:
 //!

--- a/pretty_assertions/src/printer.rs
+++ b/pretty_assertions/src/printer.rs
@@ -575,7 +575,7 @@ Cabbage"#;
 
         /// Regression test for double abort
         ///
-        /// See: https://github.com/colin-kiegel/rust-pretty-assertions/issues/96
+        /// See: https://github.com/rust-pretty-assertions/rust-pretty-assertions/issues/96
         #[test]
         fn trailing_deleted() {
             // The below inputs caused an abort via double panic


### PR DESCRIPTION
Also changes all repository references to reflect the recent organisation move, `colin-kiegel -> rust-pretty-assertions`