### PR TITLE
chore: Upgrade ctor to 0.2.0

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -35,5 +35,5 @@ diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"
-ctor = "0.1.9"
+ctor = "0.2.0"
 


### PR DESCRIPTION
`ctor` released version 0.2.0 which bumps the `syn` version to 2.x. Not sure why ctor needed to bump to a non-backwards-compatible release. There doesn't seem to be any other changes than just internal dependency upgrades.