### PR TITLE
chore: Update to ctor 0.2

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -35,5 +35,5 @@ diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"
-ctor = "0.1.9"
+ctor = "0.2.0"
 


### PR DESCRIPTION
Updates to syn 2 and gets rid of ctors syn 1 dependency.