### PR TITLE
chore: Replace ctor with std::sync::Once

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -35,5 +35,3 @@ diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"
-ctor = "0.1.9"
-


### PR DESCRIPTION
A `std::sync::Once` should effectively do the same thing as ctor, only difference is an extra check before failures whether the initialization has already been done.

Haven't tested this (on windows) but it ought to be fine. If nothing else maybe someone on windows can use this PR to test or just have faith that it is ok :)