### PR TITLE
Update ctor

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.54.0
+          - 1.56
         experimental:
           - false
         # Run a canary test on nightly that's allowed to fail

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ use pretty_assertions::{assert_eq, assert_ne};
   a diff.
 - Under Windows, the terminal state is modified to properly handle VT100
   escape sequences, which may break display for certain use cases.
-- The minimum supported rust version (MSRV) is 1.35.0
 
 ### `no_std` support
 

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Tom Milligan <code@tommilligan.net>",
 ]
 edition = "2018"
+rust-version = "1.56"
 
 description = "Overwrite `assert_eq!` and `assert_ne!` with drop-in replacements, adding colorful diffs."
 repository = "https://github.com/rust-pretty-assertions/rust-pretty-assertions"
@@ -35,5 +36,5 @@ diff = "0.1.12"
 
 [target.'cfg(windows)'.dependencies]
 output_vt100 = "0.1.2"
-ctor = "0.1.9"
+ctor = "0.2.3"
 


### PR DESCRIPTION
Mostly to remove syn 1 from my dependency tree. This increases MSRV to 1.56, so I updated the test matrix. MSRV in README seemed to be outdated so I removed that and added it to Cargo.toml instead.

I also noticed CI warnings about the deprecated `set-output` syntax, so just a heads up that that needs updating.