### PR TITLE
chore: remove stale vt100/ctor dependencies

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -32,8 +32,3 @@ unstable = []
 [dependencies]
 yansi = "0.5"
 diff = "0.1.12"
-
-[target.'cfg(windows)'.dependencies]
-output_vt100 = "0.1.2"
-ctor = "0.1.9"
-

--- a/pretty_assertions/src/lib.rs
+++ b/pretty_assertions/src/lib.rs
@@ -84,14 +84,6 @@ use core::fmt::{self, Debug, Display};
 
 mod printer;
 
-#[cfg(windows)]
-use ctor::*;
-#[cfg(windows)]
-#[ctor]
-fn init() {
-    output_vt100::try_init().ok(); // Do not panic on fail
-}
-
 /// A comparison of two values.
 ///
 /// Where both values implement `Debug`, the comparison can be displayed as a pretty diff.


### PR DESCRIPTION
As decided in [this discussion](https://github.com/rust-pretty-assertions/rust-pretty-assertions/pull/115#issuecomment-1623986652), we will remove this windows specific feature/logic as unused.

If anyone screams, we can reinstate after discussion of target environment.

