### PR TITLE
chore: update 'yansi' to 1.0.0-rc

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - windows-2019
+          - windows-2022
         rust:
           - stable
           - beta

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.54.0
+          - 1.63.0
         experimental:
           - false
         # Run a canary test on nightly that's allowed to fail

--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -30,5 +30,5 @@ alloc = []
 unstable = []
 
 [dependencies]
-yansi = "0.5"
+yansi = "1.0.0-rc.1"
 diff = "0.1.12"


### PR DESCRIPTION
Updates yansi to 1.0.0-rc. Note that 1.0.0-rc is seen as semver compatible with 1.0.0 by Cargo, so no additional change would be necessary to get yansi 1.0 once it's released. 

The main advantages to the update is 1) automatic support for Windows, 2) fewer allocations by making use of lingering, and 3) pithier styling in general.