### PR TITLE
chore: display feature-flagged docs on docs.rs

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -17,6 +17,9 @@ categories = ["development-tools"]
 keywords = ["assert", "diff", "pretty", "color"]
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = ["std"]
 


### PR DESCRIPTION
This should make `assert_matches` visible on [docs.rs](https://docs.rs/pretty_assertions/latest/pretty_assertions/#macros).