### PR TITLE
chore: rename deprecated yansi methods

### DIFF
--- a/pretty_assertions/Cargo.toml
+++ b/pretty_assertions/Cargo.toml
@@ -30,5 +30,5 @@ alloc = []
 unstable = []
 
 [dependencies]
-yansi = "1.0.0-rc.1"
+yansi = "1.0.1"
 diff = "0.1.12"

--- a/pretty_assertions/src/printer.rs
+++ b/pretty_assertions/src/printer.rs
@@ -20,9 +20,9 @@ pub(crate) fn write_header(f: &mut fmt::Formatter) -> fmt::Result {
         "{} {} {} / {} {} :",
         "Diff".bold(),
         SIGN_LEFT.red().linger(),
-        "left".clear(),
+        "left".resetting(),
         "right".green().linger(),
-        SIGN_RIGHT.clear(),
+        SIGN_RIGHT.resetting(),
     )
 }
 


### PR DESCRIPTION
Fixes the CI run for #130.

```console
error: use of deprecated method `yansi::Paint::clear`: renamed to `resetting()` due to conflicts with `Vec::clear()`.
       The `clear()` method will be removed in a future release.
```