### PR TITLE
build: Increase portability of shell scripts

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/cover
+++ b/scripts/cover
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/scripts/install
+++ b/scripts/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -exuo pipefail
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 


### PR DESCRIPTION
`/usr/bin/env bash` will search $PATH for `bash` and execute it instead of relying on it being installed in `/bin/bash`. E.g. on NixOS and several BSDs this is not the case.